### PR TITLE
Add Conjured Item and Refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/*

--- a/app/item.js
+++ b/app/item.js
@@ -1,0 +1,9 @@
+class Item {
+  constructor(name, sellIn, quality){
+    this.name = name;
+    this.sellIn = sellIn;
+    this.quality = quality;
+  }
+}
+
+module.exports = Item;

--- a/app/item.js
+++ b/app/item.js
@@ -1,3 +1,5 @@
+'use strict';
+
 class Item {
   constructor(name, sellIn, quality){
     this.name = name;

--- a/app/shop.js
+++ b/app/shop.js
@@ -25,7 +25,7 @@ class Shop {
   }
 
   updateQuality() {
-    let currItem, qualityChange = 0;
+    let currItem, qualityChange;
 
     for (let i = 0; i < this.items.length; i++) {
       currItem = this.items[i];
@@ -34,6 +34,8 @@ class Shop {
         currItem.quality = 80;
       } else {
         // update quality
+        qualityChange = 0;
+
         if (isAgedBrie(currItem)) {
           qualityChange++;
         }

--- a/app/shop.js
+++ b/app/shop.js
@@ -9,6 +9,10 @@ function isBackstagePass(item) {
   return item.name.toUpperCase().includes('BACKSTAGE PASSES');
 }
 
+function isConjured(item) {
+  return item.name.toUpperCase().includes('CONJURED');
+}
+
 function isSulfuras(item) {
   return item.name.toUpperCase() === SULFURAS;
 }
@@ -44,6 +48,8 @@ class Shop {
           qualityChange--;
         }
 
+        if (isConjured(currItem)) qualityChange *= 2;
+        
         currItem.quality += qualityChange;
         if (currItem.quality < 0) currItem.quality = 0;
         if (currItem.quality > 50) currItem.quality = 50;

--- a/app/shop.js
+++ b/app/shop.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const AGED_BRIE        = 'Aged Brie'.toUpperCase();
 const SULFURAS         = 'Sulfuras, Hand of Ragnaros'.toUpperCase();
 
@@ -49,7 +51,7 @@ class Shop {
         }
 
         if (isConjured(currItem)) qualityChange *= 2;
-        
+
         currItem.quality += qualityChange;
         if (currItem.quality < 0) currItem.quality = 0;
         if (currItem.quality > 50) currItem.quality = 50;

--- a/app/shop.js
+++ b/app/shop.js
@@ -51,7 +51,6 @@ class Shop {
           if (isConjured(currItem)) qualityChange *= 2;
         }
 
-
         currItem.quality += qualityChange;
         if (currItem.quality < 0) currItem.quality = 0;
         if (currItem.quality > 50) currItem.quality = 50;

--- a/app/shop.js
+++ b/app/shop.js
@@ -4,60 +4,43 @@ class Shop {
   }
 
   updateQuality() {
-    // iterate over all items
-    for (var i = 0; i < this.items.length; i++) { // cycle through items
-    if (this.items[i].name != 'Aged Brie' && this.items[i].name != 'Backstage passes to a TAFKAL80ETC concert') {
-      if (this.items[i].quality > 0) {
-        if (this.items[i].name != 'Sulfuras, Hand of Ragnaros') {
-          this.items[i].quality = this.items[i].quality - 1;
-        }
-      }
-    } else {
-      if (this.items[i].quality < 50) {
-        this.items[i].quality = this.items[i].quality + 1;
-        if (this.items[i].name == 'Backstage passes to a TAFKAL80ETC concert') {
-          if (this.items[i].sellIn < 11) {
-            if (this.items[i].quality < 50) {
-                this.items[i].quality = this.items[i].quality + 1;
-            }
-          }
-            if (this.items[i].sellIn < 6) {
-              if (this.items[i].quality < 50) {
-                this.items[i].quality = this.items[i].quality + 1;
-              }
-            }
-        }
-      }
-    }
-    
-    // cycle sellIn value
-    if (this.items[i].name != 'Sulfuras, Hand of Ragnaros') {
-      this.items[i].sellIn = this.items[i].sellIn - 1;
-    }
+    let currItem, qualityChange = 0;
 
-    // handle quality degredation
-    if (this.items[i].sellIn < 0) {
-      if (this.items[i].name != 'Aged Brie') {
-        if (this.items[i].name != 'Backstage passes to a TAFKAL80ETC concert') {
-          if (this.items[i].quality > 0) {
-            if (this.items[i].name != 'Sulfuras, Hand of Ragnaros') {
-              this.items[i].quality = this.items[i].quality - 1;
-            }
-          }
-        } else {
-          this.items[i].quality = 0;
-        }
+    for (var i = 0; i < this.items.length; i++) {
+      currItem = this.items[i];
+      if (currItem.name === 'Sulfuras, Hand of Ragnaros') {
+        // do nothing
+        currItem.quality = 80;
       } else {
-        if (this.items[i].quality < 50) {
-          this.items[i].quality = this.items[i].quality + 1;
+        // update quality
+        switch (currItem.name) {
+          case 'Aged Brie':
+            qualityChange++;
+            break;
+          case 'Backstage passes to a TAFKAL80ETC concert':
+            qualityChange++;
+            if (currItem.sellIn <= 10) qualityChange++;
+            if (currItem.sellIn <= 5) qualityChange++;
+            if (currItem.sellIn === 0) {
+              qualityChange = 0;
+              currItem.quality = 0;
+            }
+            break;
+          default:
+            if (currItem.sellIn <= 0 ) qualityChange--;
+            qualityChange--;
         }
+
+        currItem.quality += qualityChange;
+        if (currItem.quality < 0) currItem.quality = 0;
+        if (currItem.quality > 50) currItem.quality = 50;
+
+        // update sellin for every item
+        currItem.sellIn = (currItem.sellIn === 0) ? 0 : currItem.sellIn - 1;
       }
     }
-  }
-
-  return this.items;
-
-  }
+    return this.items;
+  };
 }
 
 module.exports = Shop;

--- a/app/shop.js
+++ b/app/shop.js
@@ -1,0 +1,63 @@
+class Shop {
+  constructor(items=[]){
+    this.items = items;
+  }
+
+  updateQuality() {
+    // iterate over all items
+    for (var i = 0; i < this.items.length; i++) { // cycle through items
+    if (this.items[i].name != 'Aged Brie' && this.items[i].name != 'Backstage passes to a TAFKAL80ETC concert') {
+      if (this.items[i].quality > 0) {
+        if (this.items[i].name != 'Sulfuras, Hand of Ragnaros') {
+          this.items[i].quality = this.items[i].quality - 1;
+        }
+      }
+    } else {
+      if (this.items[i].quality < 50) {
+        this.items[i].quality = this.items[i].quality + 1;
+        if (this.items[i].name == 'Backstage passes to a TAFKAL80ETC concert') {
+          if (this.items[i].sellIn < 11) {
+            if (this.items[i].quality < 50) {
+                this.items[i].quality = this.items[i].quality + 1;
+            }
+          }
+            if (this.items[i].sellIn < 6) {
+              if (this.items[i].quality < 50) {
+                this.items[i].quality = this.items[i].quality + 1;
+              }
+            }
+        }
+      }
+    }
+    
+    // cycle sellIn value
+    if (this.items[i].name != 'Sulfuras, Hand of Ragnaros') {
+      this.items[i].sellIn = this.items[i].sellIn - 1;
+    }
+
+    // handle quality changes
+    if (this.items[i].sellIn < 0) {
+      if (this.items[i].name != 'Aged Brie') {
+        if (this.items[i].name != 'Backstage passes to a TAFKAL80ETC concert') {
+          if (this.items[i].quality > 0) {
+            if (this.items[i].name != 'Sulfuras, Hand of Ragnaros') {
+              this.items[i].quality = this.items[i].quality - 1;
+            }
+          }
+        } else {
+          this.items[i].quality = this.items[i].quality - this.items[i].quality;
+        }
+      } else {
+        if (this.items[i].quality < 50) {
+          this.items[i].quality = this.items[i].quality + 1;
+        }
+      }
+    }
+  }
+
+  return this.items;
+
+  }
+}
+
+module.exports = Shop;

--- a/app/shop.js
+++ b/app/shop.js
@@ -1,3 +1,7 @@
+const AGED_BRIE        = 'Aged Brie';
+const BACKSTAGE_PASSES = 'Backstage passes to a TAFKAL80ETC concert';
+const SULFURAS         = 'Sulfuras, Hand of Ragnaros';
+
 class Shop {
   constructor(items=[]){
     this.items = items;
@@ -6,18 +10,18 @@ class Shop {
   updateQuality() {
     let currItem, qualityChange = 0;
 
-    for (var i = 0; i < this.items.length; i++) {
+    for (let i = 0; i < this.items.length; i++) {
       currItem = this.items[i];
-      if (currItem.name === 'Sulfuras, Hand of Ragnaros') {
+      if (currItem.name === SULFURAS) {
         // do nothing
         currItem.quality = 80;
       } else {
         // update quality
         switch (currItem.name) {
-          case 'Aged Brie':
+          case AGED_BRIE:
             qualityChange++;
             break;
-          case 'Backstage passes to a TAFKAL80ETC concert':
+          case BACKSTAGE_PASSES:
             qualityChange++;
             if (currItem.sellIn <= 10) qualityChange++;
             if (currItem.sellIn <= 5) qualityChange++;

--- a/app/shop.js
+++ b/app/shop.js
@@ -48,9 +48,9 @@ class Shop {
         } else {
           if (currItem.sellIn <= 0 ) qualityChange--;
           qualityChange--;
+          if (isConjured(currItem)) qualityChange *= 2;
         }
 
-        if (isConjured(currItem)) qualityChange *= 2;
 
         currItem.quality += qualityChange;
         if (currItem.quality < 0) currItem.quality = 0;

--- a/app/shop.js
+++ b/app/shop.js
@@ -35,7 +35,7 @@ class Shop {
       this.items[i].sellIn = this.items[i].sellIn - 1;
     }
 
-    // handle quality changes
+    // handle quality degredation
     if (this.items[i].sellIn < 0) {
       if (this.items[i].name != 'Aged Brie') {
         if (this.items[i].name != 'Backstage passes to a TAFKAL80ETC concert') {
@@ -45,7 +45,7 @@ class Shop {
             }
           }
         } else {
-          this.items[i].quality = this.items[i].quality - this.items[i].quality;
+          this.items[i].quality = 0;
         }
       } else {
         if (this.items[i].quality < 50) {

--- a/app/shop.js
+++ b/app/shop.js
@@ -1,6 +1,17 @@
-const AGED_BRIE        = 'Aged Brie';
-const BACKSTAGE_PASSES = 'Backstage passes to a TAFKAL80ETC concert';
-const SULFURAS         = 'Sulfuras, Hand of Ragnaros';
+const AGED_BRIE        = 'Aged Brie'.toUpperCase();
+const SULFURAS         = 'Sulfuras, Hand of Ragnaros'.toUpperCase();
+
+function isAgedBrie(item) {
+  return item.name.toUpperCase() === AGED_BRIE;
+}
+
+function isBackstagePass(item) {
+  return item.name.toUpperCase().includes('BACKSTAGE PASSES');
+}
+
+function isSulfuras(item) {
+  return item.name.toUpperCase() === SULFURAS;
+}
 
 class Shop {
   constructor(items=[]){
@@ -12,27 +23,25 @@ class Shop {
 
     for (let i = 0; i < this.items.length; i++) {
       currItem = this.items[i];
-      if (currItem.name === SULFURAS) {
+      if (isSulfuras(currItem)) {
         // do nothing
         currItem.quality = 80;
       } else {
         // update quality
-        switch (currItem.name) {
-          case AGED_BRIE:
-            qualityChange++;
-            break;
-          case BACKSTAGE_PASSES:
-            qualityChange++;
-            if (currItem.sellIn <= 10) qualityChange++;
-            if (currItem.sellIn <= 5) qualityChange++;
-            if (currItem.sellIn === 0) {
-              qualityChange = 0;
-              currItem.quality = 0;
-            }
-            break;
-          default:
-            if (currItem.sellIn <= 0 ) qualityChange--;
-            qualityChange--;
+        if (isAgedBrie(currItem)) {
+          qualityChange++;
+        }
+        else if (isBackstagePass(currItem)) {
+          qualityChange++;
+          if (currItem.sellIn <= 10) qualityChange++;
+          if (currItem.sellIn <= 5) qualityChange++;
+          if (currItem.sellIn === 0) {
+            qualityChange = 0;
+            currItem.quality = 0;
+          }
+        } else {
+          if (currItem.sellIn <= 0 ) qualityChange--;
+          qualityChange--;
         }
 
         currItem.quality += qualityChange;

--- a/index.js
+++ b/index.js
@@ -1,66 +1,7 @@
-class Item {
-  constructor(name, sellIn, quality){
-    this.name = name;
-    this.sellIn = sellIn;
-    this.quality = quality;
-  }
-}
-
-class Shop {
-  constructor(items=[]){
-    this.items = items;
-  }
-  updateQuality() {
-    for (var i = 0; i < this.items.length; i++) {
-      if (this.items[i].name != 'Aged Brie' && this.items[i].name != 'Backstage passes to a TAFKAL80ETC concert') {
-        if (this.items[i].quality > 0) {
-          if (this.items[i].name != 'Sulfuras, Hand of Ragnaros') {
-            this.items[i].quality = this.items[i].quality - 1;
-          }
-        }
-      } else {
-        if (this.items[i].quality < 50) {
-          this.items[i].quality = this.items[i].quality + 1;
-          if (this.items[i].name == 'Backstage passes to a TAFKAL80ETC concert') {
-            if (this.items[i].sellIn < 11) {
-              if (this.items[i].quality < 50) {
-                this.items[i].quality = this.items[i].quality + 1;
-              }
-            }
-            if (this.items[i].sellIn < 6) {
-              if (this.items[i].quality < 50) {
-                this.items[i].quality = this.items[i].quality + 1;
-              }
-            }
-          }
-        }
-      }
-      if (this.items[i].name != 'Sulfuras, Hand of Ragnaros') {
-        this.items[i].sellIn = this.items[i].sellIn - 1;
-      }
-      if (this.items[i].sellIn < 0) {
-        if (this.items[i].name != 'Aged Brie') {
-          if (this.items[i].name != 'Backstage passes to a TAFKAL80ETC concert') {
-            if (this.items[i].quality > 0) {
-              if (this.items[i].name != 'Sulfuras, Hand of Ragnaros') {
-                this.items[i].quality = this.items[i].quality - 1;
-              }
-            }
-          } else {
-            this.items[i].quality = this.items[i].quality - this.items[i].quality;
-          }
-        } else {
-          if (this.items[i].quality < 50) {
-            this.items[i].quality = this.items[i].quality + 1;
-          }
-        }
-      }
-    }
-
-    return this.items;
-  }
-}
+const Shop = require('./app/shop.js');
+const Item = require('./app/item.js');
 
 const shop = new Shop([ new Item('Aged Brie', 100, 100) ])
 shop.updateQuality();
+
 console.log(shop.items);

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
-const Shop = require('./app/shop.js');
+'use strict';
+
 const Item = require('./app/item.js');
+const Shop = require('./app/shop.js');
 
 const shop = new Shop([ new Item('Aged Brie', 100, 100) ])
 shop.updateQuality();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,248 @@
+{
+  "name": "gildedrose-kata",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
+    "chai": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
+      "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
+      "dev": true,
+      "requires": {
+        "assertion-error": "1.1.0",
+        "check-error": "1.0.2",
+        "deep-eql": "3.0.1",
+        "get-func-name": "2.0.0",
+        "pathval": "1.1.0",
+        "type-detect": "4.0.8"
+      }
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
+    },
+    "commander": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "growl": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+      "dev": true
+    },
+    "has-flag": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+      "dev": true
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.11"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.0.4.tgz",
+      "integrity": "sha512-nMOpAPFosU1B4Ix1jdhx5e3q7XO55ic5a8cgYvW27CequcEY+BabS0kUVL1Cw1V5PuVHZWeNRWFLmEPexo79VA==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.1",
+        "commander": "2.11.0",
+        "debug": "3.1.0",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.3",
+        "he": "1.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "4.4.0"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+      "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+      "dev": true,
+      "requires": {
+        "has-flag": "2.0.0"
+      }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
-    "test":  "mocha test"
+    "test":  "mocha test",
+    "test:watch": "mocha --watch ./test ./"
   },
   "engines": {
     "node": ">=6.0.0"

--- a/package.json
+++ b/package.json
@@ -5,11 +5,15 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha test"
   },
   "engines": {
     "node": ">=6.0.0"
   },
   "author": "",
-  "license": "ISC"
+  "license": "ISC",
+  "devDependencies": {
+    "chai": "^4.1.2",
+    "mocha": "^5.0.4"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
-    "test": "mocha test"
+    "test":  "mocha test"
   },
   "engines": {
     "node": ">=6.0.0"

--- a/test/item.js
+++ b/test/item.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const assert = require('chai').assert;
 
 const Item = require('../app/item.js');

--- a/test/item.js
+++ b/test/item.js
@@ -1,0 +1,26 @@
+const assert = require('chai').assert;
+
+const Item = require('../app/item.js');
+
+const testItem = new Item('Aged Brie', 100, 100);
+
+describe('Item', () => {
+  let myItem;
+  describe('constructor', () => {
+    beforeEach(() => {
+      myItem = new Item('Aged Brie', 100, 100);
+    });
+    it('should initialize the name field', done => {
+      assert.equal(myItem.name, 'Aged Brie');
+      done();
+    });
+    it('should initialize the sellIn field', done => {
+      assert.equal(myItem.sellIn, 100);
+      done();
+    });
+    it('should initialize the quality field', done => {
+      assert.equal(myItem.quality, 100);
+      done();
+    });
+  });
+});

--- a/test/shop.js
+++ b/test/shop.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const assert = require('chai').assert;
 
 const Item = require('../app/item.js');

--- a/test/shop.js
+++ b/test/shop.js
@@ -4,55 +4,117 @@ const Item = require('../app/item.js');
 const Shop = require('../app/shop.js');
 
 const agedBrie =        new Item('Aged Brie', 100, 25);
-const backstagePasses = new Item('ETC Backstage Passes', 15, 30);
-const item =            new Item('Item', 7, 7);
-const sulfuras =        new Item('Sulfuras', 100, 80);
+const backstagePasses = new Item('Backstage passes to a TAFKAL80ETC concert', 15, 30);
+const sulfuras =        new Item('Sulfuras, Hand of Ragnaros', 100, 80);
 
 describe('Shop', () => {
   let myShop;
 
   describe('updateQuality', () => {
     beforeEach(() => {
-      
+      myShop = new Shop([ new Item('Item', 5, 5) ]);
     });
 
     it('should decrement the sellIn property', done => {
       myShop.updateQuality();
       const firstItem = myShop.items[0];
-      assert.equal( firstItem.sellIn, 99 );
+      assert.equal( firstItem.sellIn, 4 );
       done();
     });
 
     it('should update the quality of the item', done => {
+      myShop.updateQuality();
+      const firstItem = myShop.items[0];
+      assert.equal( firstItem.quality, 4 );
       done();
     });
 
+    it('should decrement the quality twice when past sellIn', done =>{
+      myShop = new Shop([ new Item( 'item', 0, 10 ) ]);
+      myShop.updateQuality();
+      const firstItem = myShop.items[0];      
+      assert.equal(firstItem.quality, 8);
+      done();
+    })
+
     it('should never increment the quality of an item over 50', done => {
+      myShop = new Shop([
+        new Item('Aged Brie', 3, 50),
+        new Item('Backstage passes to a TAFKAL80ETC concert', 3, 49),
+      ]);
+      myShop.updateQuality();
+      const brie =   myShop.items[0];
+      const passes = myShop.items[1];
+      assert.equal( brie.quality, 50 );
+      assert.equal( brie.quality, 50 );      
       done();
     });
 
     describe('Aged Brie', () => {
       it('should increase the quality', done => {
+        myShop = new Shop([ agedBrie ]);
+        myShop.updateQuality();
+        const brie = myShop.items[0];
+        assert.equal(brie.quality, 26);
         done();
       });
     });
 
     describe('Sulfuras', () => {
-      it('should never decrease in quality', done => {
+      beforeEach(() => {
+        myShop = new Shop([ sulfuras ]);
+      });
+
+      it('should always be quality 80', done => {
+        myShop.updateQuality();
+        const myHandOfRag = myShop.items[0];
+        assert.equal(myHandOfRag.quality, 80);
+        done();
+      });
+
+      it('should never have to be sold', done => {
+        myShop.updateQuality();
+        const myHandOfRag = myShop.items[0];
+        assert.equal(myHandOfRag.sellIn, 100);
         done();
       });
     });
 
     describe('Backstage Passes', () => {
-      it('should increase in quality by 2 for < 10 days left', done => {
+      it('should increase in quality by 1 for > 10 days left', done => {
+        myShop = new Shop([ backstagePasses ]);
+        myShop.updateQuality();
+        const myPasses = myShop.items[0];
+        assert.equal(myPasses.quality, 31);
+        done();
+      });
+      it('should increase in quality by 2 for <= 10 days left', done => {
+        myShop = new Shop([ 
+          new Item('Backstage passes to a TAFKAL80ETC concert', 10, 0), 
+        ]);
+        myShop.updateQuality();
+        const myPasses = myShop.items[0];
+        assert.equal(myPasses.quality, 2);
         done();
       });
 
-      it('should increase in quality by 3 for < 5 days left', done => {
+      it('should increase in quality by 3 for <= 5 days left', done => {
+        myShop = new Shop([ 
+          new Item('Backstage passes to a TAFKAL80ETC concert', 5, 0), 
+        ]);
+        myShop.updateQuality();
+        const myPasses = myShop.items[0];
+        assert.equal(myPasses.quality, 3);
         done();
       });
 
       it('should drop to 0 quality after sellIn date', done => {
+        myShop = new Shop([ 
+          new Item('Backstage passes to a TAFKAL80ETC concert', 0, 999), 
+        ]);
+        myShop.updateQuality();
+        const myPasses = myShop.items[0];
+        assert.equal(myPasses.quality, 0);
         done();
       });
     });

--- a/test/shop.js
+++ b/test/shop.js
@@ -1,0 +1,21 @@
+const assert = require('chai').assert;
+
+const Shop = require('../app/shop.js');
+const Item = require('../app/item.js');
+
+const testItem = new Item('Aged Brie', 100, 100);
+
+describe('Shop', () => {
+  let myShop;
+  beforeEach(() => {
+    myShop = new Shop([ testItem ]);
+  });
+  describe('updateQuality', () => {
+    it('should decrement the sellIn property', done => {
+      myShop.updateQuality();
+      const firstItem = myShop.items[0];
+      assert.equal( firstItem.sellIn, 99 );
+      done();
+    });
+  });
+});

--- a/test/shop.js
+++ b/test/shop.js
@@ -37,6 +37,14 @@ describe('Shop', () => {
       done();
     })
 
+    it('should never decrement the quality of an item below 0', done => {
+      myShop = new Shop([ new Item( 'item', 0, 0 ) ]);
+      myShop.updateQuality();
+      const firstItem = myShop.items[0];      
+      assert.equal(firstItem.quality, 0);
+      done();
+    });
+
     it('should never increment the quality of an item over 50', done => {
       myShop = new Shop([
         new Item('Aged Brie', 3, 50),

--- a/test/shop.js
+++ b/test/shop.js
@@ -4,7 +4,7 @@ const Item = require('../app/item.js');
 const Shop = require('../app/shop.js');
 
 const agedBrie =        new Item('Aged Brie', 100, 25);
-const backstagePasses = new Item('Backstage passes to a TAFKAL80ETC concert', 15, 30);
+const backstagePasses = new Item('ETC Backstage Passes', 15, 30);
 const sulfuras =        new Item('Sulfuras, Hand of Ragnaros', 100, 80);
 
 describe('Shop', () => {

--- a/test/shop.js
+++ b/test/shop.js
@@ -10,9 +10,25 @@ const sulfuras =        new Item('Sulfuras, Hand of Ragnaros', 100, 80);
 describe('Shop', () => {
   let myShop;
 
+  describe('constructor', () => {
+    it('should have zero items when given no parameter', done => {
+      myShop = new Shop();
+      assert.equal(myShop.items.length, 0);
+      done();
+    });
+    
+    it('should initialize the items field', done => {
+      const myItem = new Item('item', 0, 0);
+      myShop = new Shop([ myItem ]);
+      assert.equal(myShop.items.length, 1);
+      assert.equal(myShop.items[0], myItem);
+      done();
+    });
+  });
+
   describe('updateQuality', () => {
     beforeEach(() => {
-      myShop = new Shop([ new Item('Item', 5, 5) ]);
+      myShop = new Shop([ new Item('item', 5, 5) ]);
     });
 
     it('should decrement the sellIn property', done => {
@@ -68,26 +84,6 @@ describe('Shop', () => {
       });
     });
 
-    describe('Sulfuras', () => {
-      beforeEach(() => {
-        myShop = new Shop([ sulfuras ]);
-      });
-
-      it('should always be quality 80', done => {
-        myShop.updateQuality();
-        const myHandOfRag = myShop.items[0];
-        assert.equal(myHandOfRag.quality, 80);
-        done();
-      });
-
-      it('should never have to be sold', done => {
-        myShop.updateQuality();
-        const myHandOfRag = myShop.items[0];
-        assert.equal(myHandOfRag.sellIn, 100);
-        done();
-      });
-    });
-
     describe('Backstage Passes', () => {
       it('should increase in quality by 1 for > 10 days left', done => {
         myShop = new Shop([ backstagePasses ]);
@@ -123,6 +119,42 @@ describe('Shop', () => {
         myShop.updateQuality();
         const myPasses = myShop.items[0];
         assert.equal(myPasses.quality, 0);
+        done();
+      });
+    });
+
+    describe('Conjured Items', () => {
+      it('should degrade in quality twice as fast before sellIn', done => {
+        myShop = new Shop([ new Item('Conjured Mana Biscuit', 10, 10) ]);
+        myShop.updateQuality();
+        assert.equal(myShop.items[0].quality, 8);
+        done();
+      });
+
+      it('should degrade in quality twice as fast after sellIn', done => {
+        myShop = new Shop([ new Item('Conjured Mana Pudding', 0, 10) ]);
+        myShop.updateQuality();
+        assert.equal(myShop.items[0].quality, 6);
+        done();
+      });
+    });
+
+    describe('Sulfuras', () => {
+      beforeEach(() => {
+        myShop = new Shop([ sulfuras ]);
+      });
+
+      it('should always be quality 80', done => {
+        myShop.updateQuality();
+        const myHandOfRag = myShop.items[0];
+        assert.equal(myHandOfRag.quality, 80);
+        done();
+      });
+
+      it('should never have to be sold', done => {
+        myShop.updateQuality();
+        const myHandOfRag = myShop.items[0];
+        assert.equal(myHandOfRag.sellIn, 100);
         done();
       });
     });

--- a/test/shop.js
+++ b/test/shop.js
@@ -1,21 +1,60 @@
 const assert = require('chai').assert;
 
-const Shop = require('../app/shop.js');
 const Item = require('../app/item.js');
+const Shop = require('../app/shop.js');
 
-const testItem = new Item('Aged Brie', 100, 100);
+const agedBrie =        new Item('Aged Brie', 100, 25);
+const backstagePasses = new Item('ETC Backstage Passes', 15, 30);
+const item =            new Item('Item', 7, 7);
+const sulfuras =        new Item('Sulfuras', 100, 80);
 
 describe('Shop', () => {
   let myShop;
-  beforeEach(() => {
-    myShop = new Shop([ testItem ]);
-  });
+
   describe('updateQuality', () => {
+    beforeEach(() => {
+      
+    });
+
     it('should decrement the sellIn property', done => {
       myShop.updateQuality();
       const firstItem = myShop.items[0];
       assert.equal( firstItem.sellIn, 99 );
       done();
+    });
+
+    it('should update the quality of the item', done => {
+      done();
+    });
+
+    it('should never increment the quality of an item over 50', done => {
+      done();
+    });
+
+    describe('Aged Brie', () => {
+      it('should increase the quality', done => {
+        done();
+      });
+    });
+
+    describe('Sulfuras', () => {
+      it('should never decrease in quality', done => {
+        done();
+      });
+    });
+
+    describe('Backstage Passes', () => {
+      it('should increase in quality by 2 for < 10 days left', done => {
+        done();
+      });
+
+      it('should increase in quality by 3 for < 5 days left', done => {
+        done();
+      });
+
+      it('should drop to 0 quality after sellIn date', done => {
+        done();
+      });
     });
   });
 });


### PR DESCRIPTION
I took some liberties with some design choices.

### Assumptions:
- 'Sulfuras' as a legendary item if given a quality above 80, will be set to equal exactly 80;
- Backstage passes are any items with names that include the string `backstage passes` (ignoring case)
- Conjured items are any items with names that include the string `conjured` (ignoring case)
- Conjured Aged Brie and Backstage Passes are treated as normal

### Changelist:
- Added `mocha` and `chai` as dev dependencies for testing purposes
- Created testing suite for `Item` and `Shop`.
- Added `npm run test` and `npm run test:watch` commands to `package.json` for testing purposes
- Refactored `Item` and `Shop` into separate files located within a new directory `./app/`
- Refactored and simplified core `Shop.updateQuality()` logic to reduce logic trees and increase readability
- Added `Conjured` item logic. See line 53 of `./app/shop.js`
- Added `.gitignore` to remove `node_modules` from SRC